### PR TITLE
Env variable token, executable bot, package relocation and more

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     kotlin("jvm") version "1.6.10"
 }
 
-group = "me.xbilikx"
+group = "me.xbilikx.dismoralbot"
 version = "1.0-SNAPSHOT"
 
 repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,9 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
+    application
     kotlin("jvm") version "1.6.10"
+    id("com.github.johnrengelman.shadow") version "7.1.2"
 }
 
 group = "me.xbilikx.dismoralbot"
@@ -19,9 +21,22 @@ repositories {
 dependencies {
     implementation("dev.kord:kord-core:0.8.0-M8")
     implementation("com.kotlindiscord.kord.extensions:kord-extensions:1.5.1-RC1")
+    implementation("org.slf4j:slf4j-simple:1.7.33")
 //    implementation("clojure-interop:java.awt:1.0.2")
 }
 
-tasks.withType<KotlinCompile>() {
+application {
+    mainClass.set("me.xbilikx.dismoralbot.BotMainKt")
+}
+
+tasks.jar {
+    manifest {
+        attributes(
+            "Main-Class" to "me.xbilikx.dismoralbot.BotMainKt"
+        )
+    }
+}
+
+tasks.withType<KotlinCompile> {
     kotlinOptions.jvmTarget = "1.8"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/BotMain.kt
+++ b/src/main/kotlin/BotMain.kt
@@ -10,10 +10,10 @@ import kotlinx.datetime.Instant
 import org.koin.core.component.get
 
 lateinit var botClient: User
-private set
+    private set
 
 suspend fun main() {
-    val bot = ExtensibleBot(Keys.API_KEY){
+    val bot = ExtensibleBot(Constants.BOT_TOKEN){
         chatCommands {
             defaultPrefix = "?"
             enabled = true

--- a/src/main/kotlin/Constants.kt
+++ b/src/main/kotlin/Constants.kt
@@ -1,5 +1,7 @@
+import com.kotlindiscord.kord.extensions.utils.env
 import dev.kord.common.Color
 
 object Constants {
+    val BOT_TOKEN = env("TOKEN") // Get environment variable
     val EMBED_COLOR = Color(127,0,0)
 }

--- a/src/main/kotlin/me/xbilikx/dismoralbot/AddTextToImage.kt
+++ b/src/main/kotlin/me/xbilikx/dismoralbot/AddTextToImage.kt
@@ -1,3 +1,5 @@
+package me.xbilikx.dismoralbot
+
 import java.awt.AlphaComposite
 import java.awt.Color
 import java.awt.Font
@@ -5,7 +7,6 @@ import java.awt.RenderingHints
 import java.awt.image.BufferedImage
 import java.io.File
 import java.io.IOException
-import java.net.URL
 import javax.imageio.ImageIO
 
 

--- a/src/main/kotlin/me/xbilikx/dismoralbot/BotMain.kt
+++ b/src/main/kotlin/me/xbilikx/dismoralbot/BotMain.kt
@@ -1,5 +1,7 @@
-import Extensions.MyHelpExtension
-import Extensions.TestExtension
+package me.xbilikx.dismoralbot
+
+import me.xbilikx.dismoralbot.extensions.MyHelpExtension
+import me.xbilikx.dismoralbot.extensions.TestExtension
 import com.kotlindiscord.kord.extensions.ExtensibleBot
 import dev.kord.common.entity.PresenceStatus
 import dev.kord.core.Kord

--- a/src/main/kotlin/me/xbilikx/dismoralbot/Constants.kt
+++ b/src/main/kotlin/me/xbilikx/dismoralbot/Constants.kt
@@ -1,3 +1,5 @@
+package me.xbilikx.dismoralbot
+
 import com.kotlindiscord.kord.extensions.utils.env
 import dev.kord.common.Color
 

--- a/src/main/kotlin/me/xbilikx/dismoralbot/extensions/BotSettingsExtension.kt
+++ b/src/main/kotlin/me/xbilikx/dismoralbot/extensions/BotSettingsExtension.kt
@@ -1,9 +1,9 @@
-package Extensions
+package me.xbilikx.dismoralbot.extensions
 
 import com.kotlindiscord.kord.extensions.extensions.Extension
 
-class MemesExtension: Extension() {
-    override val name: String = "memes"
+class BotSettingsExtension: Extension() {
+    override val name: String = "settings"
 
     override suspend fun setup() {
         TODO("Not yet implemented")

--- a/src/main/kotlin/me/xbilikx/dismoralbot/extensions/MemesExtension.kt
+++ b/src/main/kotlin/me/xbilikx/dismoralbot/extensions/MemesExtension.kt
@@ -1,9 +1,9 @@
-package Extensions
+package me.xbilikx.dismoralbot.extensions
 
 import com.kotlindiscord.kord.extensions.extensions.Extension
 
-class BotSettingsExtension: Extension() {
-    override val name: String = "settings"
+class MemesExtension: Extension() {
+    override val name: String = "memes"
 
     override suspend fun setup() {
         TODO("Not yet implemented")

--- a/src/main/kotlin/me/xbilikx/dismoralbot/extensions/MyHelpExtension.kt
+++ b/src/main/kotlin/me/xbilikx/dismoralbot/extensions/MyHelpExtension.kt
@@ -1,4 +1,4 @@
-package Extensions
+package me.xbilikx.dismoralbot.extensions
 
 import com.kotlindiscord.kord.extensions.builders.ExtensibleBotBuilder
 import com.kotlindiscord.kord.extensions.commands.Arguments

--- a/src/main/kotlin/me/xbilikx/dismoralbot/extensions/TestExtension.kt
+++ b/src/main/kotlin/me/xbilikx/dismoralbot/extensions/TestExtension.kt
@@ -1,20 +1,14 @@
-package Extensions
+package me.xbilikx.dismoralbot.extensions
 
-import AddTextImage
+import me.xbilikx.dismoralbot.AddTextImage
 import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.extensions.chatCommand
 import com.kotlindiscord.kord.extensions.utils.respond
-import createEmbed
 import dev.kord.core.behavior.channel.createMessage
 import dev.kord.rest.NamedFile
-import dev.kord.rest.builder.message.EmbedBuilder
 import java.awt.Color
 import java.awt.Font
 import java.io.File
-import java.io.IOException
-import java.nio.file.Files
-import java.nio.file.Paths
-import java.util.function.Consumer
 
 
 class TestExtension: Extension() {
@@ -47,7 +41,7 @@ class TestExtension: Extension() {
             action {
                 message.delete()
                 val channel = message.channel
-//                channel.createEmbed("asdasd", message.author, commandDescription, message.timestamp)
+//                channel.me.xbilikx.dismoralbot.createEmbed("asdasd", message.author, commandDescription, message.timestamp)
                 val img = AddTextImage(
                     "meta-files\\memes\\Sonic.png", Color.WHITE, Font.BOLD, "Arial",
                     "left-text-mode", "Temp.png"


### PR DESCRIPTION
- Updated GradleWrapper to newer version (idk why you're using oudated one)
- Bot token is environment variable now (to avoid non-existing key class on `git clone`)
- Moved everything to `me.xbilikx.dismoralbot` package
- Renamed `Extensions` package to `extensions` to match java coding conventions
- Added application plugin to run bot via Gradle (if needed)
- Added shadow gradle plugin. All libraries should be shipped with your bot (40 MB jar, huh)
- Added manifest attribute to make bot executable
- Added SLF4J dependency to avoid Kord warning (see https://github.com/kordlib/kord/wiki/Logging)